### PR TITLE
Fix yaml syntax and add comment to explain the cron syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ name: Example
 
 on:
   schedule:
-    cron: '0 0 * * *'
+    - cron: '12 22 * * *' # Runs at 22:12 UTC every day
 
 jobs:
   # Best used in combination with actions/stale to assign a Stale label


### PR DESCRIPTION
Per the [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule), there is a dash missing in the syntax of the schedule. I also added a more generic execution time and a comment to explain its meaning.